### PR TITLE
What we write - Redo of does_this_belong_on_mdn and editorial

### DIFF
--- a/contrib-docs/how-to-write/conventions_definitions/index.md
+++ b/contrib-docs/how-to-write/conventions_definitions/index.md
@@ -1,0 +1,227 @@
+---
+title: MDN conventions and definitions
+slug: MDN/Guidelines/Conventions_definitions
+tags:
+  - Documentation
+  - Guide
+  - Guidelines
+  - MDN
+  - MDN Meta
+---
+{{MDNSidebar}}
+
+This article defines some conventions and definitions that are commonly used on MDN, which might not be obvious to some people when they come across them in the documentation.
+
+## Definitions
+
+### Deprecated and obsolete
+
+**Deprecated** and **obsolete** are common terms associated with technologies and specifications, but what do they mean?
+
+- Deprecated
+  - : On MDN, the term **deprecated** is used to mark an API or technology that is no longer recommended, but is still implemented and may still work.
+    More recently, we've updated it to the definition used in our [browser-compat-data project](https://github.com/mdn/browser-compat-data/blob/main/schemas/compat-data-schema.md), which is that "the feature is no longer recommended. It might be removed in the future or might only be kept for compatibility purposes. Avoid using this functionality."
+- Obsolete
+  - : On MDN, the term **obsolete** was used to mark an API or technology that is not only no longer recommended, but also no longer implemented in browsers.
+    This was, however, confusing — it is similar to **deprecated**, and the distinction is not very helpful (you still shouldn't use it in a production site).
+    We are, therefore, not using it anymore, and any instances you come across should be removed/replaced by the term **deprecated**.
+
+### Experimental
+
+**Experimental** can mean different things depending on the context you hear or read it in.
+When a technology is described as experimental on MDN, it means that the technology is nascent and immature, and currently in the process of being added to the Web platform (or considered for addition).
+
+One or both of these will be true:
+
+- It is implemented and enabled by default in less than two modern major browsers.
+- Its defining spec is likely to change significantly, in backwards-incompatible ways (i.e. it may break existing code that relies on the feature).
+
+If one or both of these definitions is true, then you should think carefully before you start using that technology in any kind of production project (i.e. not just a demo or experiment).
+See also the definition of experimental in our [browser-compat-data project](https://github.com/mdn/browser-compat-data/blob/main/schemas/compat-data-schema.md#status-information).
+
+Conversely, an item is no longer experimental when:
+
+- It is implemented in two or more major browsers; or
+- Its defining spec is unlikely to change in ways that will break the web.
+
+The _or_ is important here — usually if a technology is supported across several major browsers, the spec will be stable, but this is not always the case.
+And some technologies will have a stable spec and be well-used, but have no native support in browsers ([IMSC](/en-US/docs/Related/IMSC), for example).
+
+### Archived pages
+
+Archived pages are pages that are stored in the MDN [Archive of obsolete content](/en-US/docs/Archive).
+These pages contain information out-of-date enough that it is not directly useful to anyone anymore.
+
+Most commonly, these concern Mozilla projects that have been discontinued and shouldn't be relied on anymore.
+But we don't delete them because they form a useful historical record, and some of the patterns or ideas contained within might be useful for future work.
+A good example is the [B2G (Firefox OS) project](/en-US/docs/Archive/B2G_OS).
+
+#### When should a page be archived?
+
+A page should be archived if it fits the above description.
+To archive a page, you should use the "Move page feature" (_Advanced > Move this article_) to move the page into the Archive page tree (/en-US/docs/Archive).
+You might not have the permissions to use this feature, and before you start archiving pages you should discuss it with the MDN community first — talk to us on our [Discourse forum](https://discourse.mozilla.org/c/mdn/236).
+
+### Deleted pages
+
+Deleted pages are pages that have been explicitly deleted from MDN — see for example the [`SharedKeyframeList`](/en-US/docs/Web/API/SharedKeyframeList) interface and [`SharedKeyframeList()`](/en-US/docs/Web/API/SharedKeyframeList/SharedKeyframeList) constructor.
+These pages contain information that is not useful in any way anymore, and/or might be incorrect to the point where keeping it available might be confusing or bad for people to know.
+
+These might be:
+
+- Reference pages for API features that were removed from the specification before they were implemented in any browsers.
+- Articles covering techniques that were later shown to be bad practice and superseded by better techniques.
+- Articles containing information that were later replaced by other, better quality articles.
+- Articles containing content that is inappropriate for MDN.
+- Translations that are old, out-of-date, and difficult to fix, meaning that the English version is preferable and starting a new translation would be an easier option.
+
+#### When should a page be deleted?
+
+A page should be deleted if it fits the above description.
+To delete a page, you should use the "Delete this page feature" (_Advanced > Delete this page_) to delete the page.
+You will probably not have the permissions to use this feature, and when thinking about deleting pages you should discuss it with the MDN community first — talk to us on our [Discourse forum](https://discourse.mozilla.org/c/mdn).
+
+### When to document new technologies
+
+On MDN, we are constantly looking to document new web standards technologies as appropriate.
+We try to strike a balance between publishing the documentation early enough so developers can learn about new features as soon as they need to, and publishing it late enough so that the technology is mature and stable so the docs won't need constant updates or rapid removal.
+
+In general, our definition of the earliest we'll consider documenting a new technology is:
+
+_"When the feature is on a standards track and is implemented somewhere."_
+
+You should definitely consider documenting a new technology if:
+
+- It is specified in a specification document published under a reliable standards organization (such as W3C, WHATWG, Khronos, IETF, etc.), which has reached a reasonable level of stability (e.g. a W3C working draft or candidate recommendation, or the spec is looking to be fairly stable judging by the flow of issues filed against it).
+- It is implemented consistently in at least one browser, with other browser developers showing signs of interest (such as an active ticket or "intent to implement" process in effect).
+
+You should be more wary of documenting a new technology (but should still consider it if it makes sense) if it:
+
+- Doesn't have a spec, or the spec is a rough note that looks liable to change.
+- One or zero browsers currently implement it, and non-supporting browsers are not showing signs of interest in implementing it (you can gauge this by asking engineers who work on those browsers, looking at browser bug trackers and mailing lists, etc.).
+
+You should not consider documenting a new technology if it:
+
+- Is not a web-exposed technology and/or is completely proprietary.
+- Is already showing signs of being deprecated, or superseded by a similar feature.
+
+## Conventions
+
+### When something is removed from the specification
+
+Sometimes during the development of a new specification, or over the course of the evolution of living standards such as HTML, new elements, methods, properties, and so forth are added to the specification, stay there for a while, then get removed again.
+Sometimes this happens very quickly, and sometimes these new items remain in the specification for months or even years before being removed.
+This can make it tricky to decide how to handle the removal of the item from the spec.
+Here are some guidelines to help you decide what to do.
+
+> **Note:** For the purposes of this discussion, the word "item" is used to mean anything which can be part of a specification: an element or an attribute of an element, an interface or any individual method, property, or other member of an interface, and so forth.
+
+- If the item was _never_ implemented in a release version of _any_ browser—even behind a preference or flag—delete any references to the item from the documentation.
+
+  - If the item has any documentation pages describing only that one item (such as {{domxref("RTCPeerConnection.close()")}}), delete that page.
+    If the removed item is an interface, this means removing any subpages describing the properties and methods on that interface as well.
+  - Remove the item from any lists of properties, attributes, methods, and so forth.
+    For methods of an interface, that means to remove it from the "Methods" section on the interface's overview page, for example.
+  - Search the text of the overview page for that interface, element, etc. for any references to the removed item.
+    Remove those references, being sure not to leave weird grammar issues or other problems with the text.
+    This may mean not just deleting words but rewriting a sentence or paragraph to make more sense.
+    It may also mean removing entire sections of content if the description of the item's use is lengthy.
+  - Similarly, look for any discussion of the item in the guides and tutorials about the relevant API or technology.
+    Remove those references, being sure not to leave weird grammar issues or other problems with the text.
+    This may mean not just deleting words but rewriting a sentence or paragraph to make more sense.
+    It may also mean removing entire sections of content if the description of the item's use is lengthy.
+  - Search MDN for references to the removed item, in case there are discussions elsewhere.
+    It's unlikely that there are, since if it was never implemented, it's unlikely to be widely discussed.
+    Remove those mentions as well.
+  - If the [Browser Compatibility Data repository's](https://github.com/mdn/browser-compat-data) JSON files contain data for the removed items, delete those objects from the JSON code and submit a PR with that change, explaining why in the commit message and the PR description.
+    Be careful to check that you don't break the JSON syntax while doing this.
+
+- If the item was implemented in any release version of any one or more browsers—but _only_ behind a preference or flag—do not delete the item from the documentation immediately.
+  Instead, mark the item as deprecated as follows:
+
+  - If the item has any documentation pages describing only that one item (such as {{domxref("RTCPeerConnection.close()")}}), add the [`deprecated_header`](https://github.com/mdn/yari/blob/main/kumascript/macros/Deprecated_Header.ejs) macro to the top of the page and add the {{tag("Deprecated")}} tag to the page's list of tags.
+  - On the overview page for the element, interface, or API, find the list of items which includes the item that's been removed from the specification and add the [`deprecated_inline`](https://github.com/mdn/yari/blob/main/kumascript/macros/Deprecated_Inline.ejs) macro after the item's name in that list.
+  - Search the informative text of the overview page for that interface, element, etc. for any references to the removed item.
+    Add warning boxes in appropriate places with text along the lines of "\[whatever] has been removed from the specification and will be removed from browsers soon.
+    See \[link to page] for a new way to do this."
+  - Similarly, look for any discussion of the item in the guides and tutorials about the relevant API or technology. Add similar warnings.
+  - Search MDN for references to the removed item, in case there are discussions elsewhere.
+    Add similar warning boxes there as well.
+  - At some point in the future, a decision may be made to actually remove the item from the documentation; we don't normally do this but if the item was especially unutilized or uninteresting, we may decide to do so.
+  - Update any relevant entries in the [Browser Compatibility Data repo](https://github.com/mdn/browser-compat-data) to reflect the obsolescence of the item(s) affected.
+
+- If the item was implemented in one or more release builds of browsers—without requiring a preference or flag to be changed—mark the item as deprecated, as follows:
+
+  - If the item has any documentation pages describing only that one item (such as {{domxref("RTCPeerConnection.close()")}}), add the [`deprecated_header`](https://github.com/mdn/yari/blob/main/kumascript/macros/Deprecated_Header.ejs) macro to the top of the page and add the {{tag("Deprecated")}} tag to the page's list of tags.
+  - On the overview page for the element, interface, or API, find the list of items which includes the item that's been removed from the specification and add the [`deprecated_inline`](https://github.com/mdn/yari/blob/main/kumascript/macros/Deprecated_Inline.ejs) macro after the item's name in that list.
+  - Search the informative text of the overview page for that interface, element, etc. for any references to the removed item.
+    Add warning boxes in appropriate places with text along the lines of "\[whatever] has been removed from the specification and is deprecated.
+    It may be removed from browsers in the future, so you should not use it.
+    See \[link to page] for a new way to do this."
+  - Similarly, look for any discussion of the item in the guides and tutorials about the relevant API or technology. Add similar warnings.
+  - Search MDN for references to the removed item, in case there are discussions elsewhere.
+    Add similar warning boxes there as well.
+  - It's unlikely that these items will be removed from the documentation anytime soon, if ever.
+    It's possible, however, that some or all of the material may be moved to the [Archive](/en-US/docs/Archive) section of the site.
+  - Update any relevant entries in the [Browser Compatibility Data repo](https://github.com/mdn/browser-compat-data) to reflect the deprecation of the item(s) affected.
+
+Please use common sense with wording of warning messages and other changes to text suggested by the guidelines above.
+Different items will require different wording and handling of the situation.
+When in doubt, feel free to ask for advice on the [MDN Web Docs chat room](https://chat.mozilla.org/#/room/#mdn:mozilla.org) on [Matrix](https://wiki.mozilla.org/Matrix), or on the [MDN Web Docs discussion forum](https://discourse.mozilla.org/c/mdn).
+
+### Copying content within MDN
+
+Sometimes, you need to reuse the same text on multiple pages (or you want to use one page's content as a template for another page).
+You have three options:
+
+- If you want to copy an entire page:
+
+  1. While viewing the page you want to copy, on the **Advanced** (gear) menu, choose  **[Clone this page](/en-US/docs/MDN/Contribute/Howto/Create_and_edit_pages#clone_of_an_existing_page)**.
+     This opens the editor UI for a new page, with the contents of the cloned page already populated.
+  2. Enter a new **Title** and **Slug** for the cloned page.
+  3. Edit the contents of the page as needed, and save as usual.
+
+- If you want to copy just part of a page, **don't just visit the page and copy from it**.
+  This introduces unwanted additional bits of HTML into the destination page, and somebody will have to clean that up, you or another editor.
+  Nobody wants that.
+  To copy part of an MDN page to another page:
+
+  1. On the source page, click the **Edit** button on the source page.
+  2. **Copy the content you want to reuse from within the editor UI.**
+  3. Click **Discard** to exit the editor UI for that page.
+  4. Open the editor UI for page where you want to paste.
+  5. Paste the content from the clipboard.
+
+  > **Note:** Chrome does not generally include the classes applied to content when copying and pasting across documents in our editor.
+  > You need to review the content after doing this and re-apply the lost styles.
+  > Check tables, syntax boxes, syntax highlighting, and hidden sections of content in particular.
+
+- Sometimes you literally want to use the same content on many pages.
+  In this case, you might be best off placing the content in one page, then using the [`page`](https://github.com/mdn/yari/blob/main/kumascript/macros/page.ejs) macro to transclude the material from one page into another.
+  This way, whenever the text on the source page is updated, the destination page will update as well (that is, this will happen on a forced-refresh or when the target page goes through a scheduled rebuild).
+
+#### Copying content from elsewhere
+
+Often, there is useful content about a topic somewhere on the web besides on MDN.
+However, copying such content can be fraught with difficulties, both legal and technical.
+
+On the technical level, search engines typically penalize a site in their rankings for reproducing content available elsewhere.
+Therefore, it is preferable to have original content on MDN, to enhance the search engine ranking of MDN's content.
+You can link to the existing content from MDN.
+
+On the legal level, you must be authorized to contribute the content, and it must be licensed and attributed in a way that is compatible with [MDN's license](/en-US/docs/MDN/About#copyrights_and_licenses).
+
+- **If you created the existing content** (for your own purposes and not as work-for-hire), and you are willing to contribute it to MDN under MDN's license, this is the easiest case, and you are free to contribute the content.
+- **If the copyright for the content belongs to someone else**, it must be licensed and attributed compatibly with MDN's license.
+  It is often not easy for someone who is not a lawyer to determine what licenses are compatible.
+  To be on the safe side, contact a member of the [MDN staff team](https://wiki.mozilla.org/MDN#Staff_Team), who may consult Mozilla's Legal team for guidance if necessary.
+
+#### How to communicate a spec conflict
+
+Note that sometimes (but rarely) there is a conflict between different spec versions (usually W3C versus WHATWG), e.g. one version might have a feature listed as deprecated, while the other doesn't.
+In such cases, consider what the reality is — i.e. what browsers are actually doing — and write an "important" note to summarize that latest status.
+For example, as of Jan 2019 the [`inputmode`](/en-US/docs/Web/HTML/Global_attributes/inputmode) global attribute has a conflict, which was summarized like so:
+
+> **Warning:** Spec conflict: The [WHATWG spec lists `inputmode`](https://html.spec.whatwg.org/multipage/interaction.html#attr-inputmode), and modern browsers are working towards supporting it.
+> The [W3C HTML 5.2 spec](https://html.spec.whatwg.org/multipage/index.html#contents) however no longer lists it (i.e. marks it as obsolete).
+> You should consider the WHATWG definition as correct, until a consensus is reached.=

--- a/contrib-docs/how-to-write/criteria_for_inclusion/index.md
+++ b/contrib-docs/how-to-write/criteria_for_inclusion/index.md
@@ -1,0 +1,56 @@
+---
+title: Criteria for inclusion
+slug: Related/Criteria_for_inclusion
+tags:
+  - Related
+  - criteria
+---
+This document outlines the criteria for inclusion that a technology must pass before we will consider it for inclusion in the MDN Web Docs [Web-related technologies](/en-US/docs/Related) section. The aim here is to provide a guide you can follow to quickly work out if a non-web standards technology is suitable for inclusion.
+
+## Web standards technologies
+
+The MDN Web Docs remit is to document web standards technologies, or more specifically technologies that follow our standard guidelines of [when to document new technologies](/en-US/docs/MDN/Guidelines/Conventions_definitions#when_to_document_new_technologies) — the short version of this is that we document technologies on MDN Web Docs when they are specified in a specification published by a reliable standards body, and are supported in at least one browser.
+
+These criteria signify enough interest, stability, and intent to implement by the web industry at large that we think they are a safe bet to document without wasting our time. Any earlier than that, and they may be cancelled due to lack of interest, or be so unstable that they will change significantly, meaning lots of rewriting (which we try to avoid where possible).
+
+## Non-web standards technologies
+
+Non-web standards technologies are technologies that do not follow our criteria summarized above. We would not normally consider them for documentation on MDN. However, there are many technologies that are not web standards, but are useful and interesting to web developers — think about developer tools, libraries, and frameworks as some of the more obvious examples.
+
+Our mission statement is _"to provide developers with the information they need to easily build projects on the open Web"_. This suggests that we should consider documenting technologies that are useful to web developers, even if they are not open web standards, on the standards track, etc. Hence the creation of the Web-related technologies section as a place to house such documentation.
+
+We want to maintain a certain level of quality on MDN, and not just open our doors to accept any documentation. To do so would make MDN Web Docs a messy place, and potentially harm the web industry by creation substandard, conflicting documentation.
+
+Therefore, if you want to consider a non-web standard technology for inclusion in this section of MDN Web Docs, you should make sure that it matches the below criteria.
+
+## The criteria
+
+To be applicable for consideration, technologies should...
+
+### Be open and not proprietary
+
+At Mozilla we are supporters of open technologies, and don't wish to support closed technology ecosystems that are controlled by a single entity, not open for contributions by any interested party, and not interoperable across multiple platforms and systems. We believe that technology works better for humans when created out in the open.
+
+### Be web-exposed in some way / related to web technologies
+
+Our central remit is web standards technologies; there is no point starting to document technologies that do not relate to the web, or hold any interest to web developers.
+
+### Show signs of interest and adoption
+
+We don't want to waste our time and energy helping to document a technology that has no signals of interest and adoption from industry. It may just be that it is too early to start documenting the technology, and we could consider it in the future.
+
+### Not be showing signs of being deprecated, or superseded
+
+Related to the above point, we also don't want to waste our time helping to document something that is late in its lifecycle, and already showing signs of decline in interest.
+
+### Not have an established documentation resource elsewhere
+
+There are many libraries and frameworks in existence, which are not web standards, but are built on top of web technologies and very popular in the web industry. We do not document any of these because in general they all have established documentation resources already. It would be foolish to compete with the official resource of a popular framework — to do so would be a waste of time and probably end up confusing developers trying to learn the technology.
+
+### Have a community willing to write and maintain the docs
+
+The MDN Web Docs team concentrates on documenting the open web platform, and does not have time to spend on other documentation resources outside this remit. Therefore if you want a technology to be considered for documentation in this area of MDN Web Docs, you'll need to have a community assembled that is willing to write the documentation and maintain it after completion. Our team is happy to provide guidance in such cases, including edits and feedback, but we don't have time for much more than that.
+
+## Next steps
+
+If your chosen technology looks to meet the criteria, the next step is to propose it to the MDN team. See the [Process for selection](/en-US/docs/Related/Process_for_selection).

--- a/contrib-docs/how-to-write/process_for_selection/index.md
+++ b/contrib-docs/how-to-write/process_for_selection/index.md
@@ -1,0 +1,51 @@
+---
+title: Process for selection
+slug: Related/Process_for_selection
+tags:
+  - Related
+  - selection process
+---
+If a technology looks like a good candidate for inclusion on the [Web-related technologies](/en-US/docs/Related) section of the site, the next stage is to contact us to discuss the technology, and propose why you think it should be included on MDN Web Docs. This article provides a list of what you should send to us in the proposal, along with how to send it over.
+
+## Checklist
+
+Non-web standards technologies will be considered for inclusion on MDN Web Docs on a case-by-case basis. For consideration, we need a short document describing:
+
+- The technology, its core purpose/use cases, and target developer audience.
+- What kind of industry/community buzz there is around the technology. For example:
+
+  - Are lots of people using it? What is the industry adoption like?
+  - Do lots of people want this information? Who?
+  - What kind of target audience size is there for this information? Supporting statistics would help, if you have them.
+
+- How the technology relates to core web technology and web browsers. Useful details are things like:
+
+  - Does it use HTML and CSS, but generally not output to the web?
+  - Is it supported in web browsers via a polyfill?
+
+- What documentation/resources there are available already that cover the technology.
+- How much documentation would need to be added to MDN:
+
+  - List the expected number of guides, tutorials, reference pages for elements/methods/attributes, etc.
+  - Provide a high level table of contents.
+  - Mention the kind of "advanced" features you think you might need for this resource, beyond basic documentation pages. Are you expecting to include embedded videos, interactive code samples, etc.?
+
+- Details on who will be writing the documentation. Who are these people, and why are they suited to the job?
+
+You don't need to provide us with hundreds of pages of detail at this stage (in fact, we'd prefer it if you didn't). A couple of paragraphs on each of the above points is more than adequate. We are OK to accept any format as long as it is common and easy to send over the web. Text files, documents or slides are recommended.
+
+## Submission and next steps
+
+- After you've compiled the above document, send it to us over e-mail at <mdn-admins@mozilla.org>.
+- After we receive this, we will consider the technology, then e-mail you back with one of the following answers:
+
+  - **No**: We don't think this fits MDN Web Docs.
+  - **Maybe**: We are not sure if this fits MDN Web Docs, and would like to ask some further questions.
+  - **Yes**: We think this fits MDN Web Docs.
+
+- If the response was maybe/yes, we will request a conversation (e.g. video, telephone, or email) with one or more representatives of the community interested in adding the documentation.
+- If we still feel positive after the initial conversation, then we are good to go, and a member of our team will assist you in getting started with the documentation.
+
+## See also
+
+[Project guidelines](/en-US/docs/Related/Project_guidelines) — what you need to know to create a successful documentation project once your idea has been accepted onto MDN Web Docs.

--- a/contrib-docs/how-to-write/project_guidelines/index.md
+++ b/contrib-docs/how-to-write/project_guidelines/index.md
@@ -1,0 +1,124 @@
+---
+title: Project guidelines
+slug: Related/Project_guidelines
+tags:
+  - Related
+  - project guidelines
+---
+If you've had your chosen technology accepted for documentation on MDN Web Docs, the next step is to get started. This article provides you with all you need to know to get started on documenting your project.
+
+## What does a successful project need?
+
+A successful documentation project requires a number of things. We'll look at each of these in turn:
+
+- A dedicated team
+- A Project plan/roadmap
+- Guidelines and standards
+- An intuitive structure
+- Maintenance
+
+## Dedicated team
+
+Make sure you have a dedicated team in place that will be there both to write the documentation in the first place, and maintain it after the major bulk of the work is completed and updates are required.
+
+Have a think about how much work there is to do on your particular docs project, and how many people you might need for that.
+
+If it is a large project, you might benefit from having a few writers, a technical reviewer to check that the work is correct, a copy editor to clean up the language, someone to write code examples, etc.
+
+On a smaller project, you might have one or two people taking on multiple roles. Whatever you want to do is fine, as long as it works for you. You will be assigned a member of MDN staff to provide guidance on the MDN Web Docs side of things, and advice and help in general.
+
+You should assign one (or two) team leads, to act as a central point of contact for the MDN team member, and anyone else wishing to contact the team about it (you might get more offers of help, for example).
+
+Once your team is assembled, you'll need to get them all to [create MDN accounts](/en-US/docs/MDN/Contribute/Howto/Create_an_MDN_account), and then talk to your MDN rep to work out what site permissions each person needs (e.g. creating pages, moving pages, etc.)
+
+## Project plan/roadmap
+
+Write down a plan for the work — what needs to be done, and when? What milestones do you need to reach so that progress is healthy? If the project is large, you should consider getting one of your team members to be a project manager for the project, and using a project tracking tool like [Trello](https://trello.com/). You should also consider writing a sub-project plan for an initial release that encompasses the minimum set of documentation that is useful to publish (a _minimum viable product_), do that first, and then follow up with further additions later.
+
+If the documentation resource is small, then this probably isn't so critical, but you still need to keep a record of what has been done and what hasn't, what stage each part of the documentation is at (e.g. not started, in progress, draft written, reviewed, done...), and who is working on what.
+
+## Guidelines and standards
+
+There are [guidelines available on MDN](/en-US/docs/MDN/Guidelines) that state how we expect documents to be written, and how to use the tools on the site to create them.
+
+Since this is a project in its own right, you may have additional guidelines on language or code styles that you expect to be followed. Feel free to keep a record of these, and even host them on a page inside your own project pages.
+
+In terms of standards, you are expected to maintain a reasonable level of quality for your documentation to stay on MDN. Your MDN rep will work with you on this to make you clear on what is expected. It is a good idea to produce a prototype showing what each type of page in your documentation should look like (e.g. an element or method reference page, a code example...) so that people have a template to follow.
+
+> **Note:** MDN is primarily an English site (en-US). The primary language for your resource should be in US English. If this really doesn't make sense for your project (e.g. it might be for a tool usable in a specific non-English locale), then talk to us about it, and we'll see how we can accommodate this.
+
+## Intuitive structure
+
+If you went through the submission process then you should already have a rough plan of what you are going to write for your documentation resource. At this point you should refine that into a site structure plan — think about what the document hierarchy will be, and where everything will fit and link together.
+
+Each project will be different, but we'd roughly recommend something like this:
+
+```
+Landing page
+|
+------Reference
+      |
+      --------Elements
+      |
+      --------Methods
+      |
+      --------Other reference page type(s)?
+|
+------Guides/tutorials
+|
+------Examples
+|
+------Project metadata
+```
+
+### Page templates
+
+Each page type that you will use in your project should have a page template for others to copy the structure from. You should decide on these early on.
+
+#### Landing page
+
+The landing page should contain something like:
+
+- Introductory paragraph to say what the technology is and why it's exciting.
+- Concepts and usage — why the technology exists, use cases, target audience, and a brief description of how it is used. This should be a taster, and not too much detail. If there is a lot to say here, feel free to spin it out to a separate "Concepts" article that can live in the Guides/tutorials section.
+- List of reference docs, guides, and examples — list these in separate sections, with links and descriptions of what they do. For code examples, you can show code snippets in your pages, but you are also advised to create some kind of repo to contain full examples for people to learn from, on [GitHub](https://github.com/) for example.
+- Specifications — it is useful to link to specifications and other such documents that define and provide context to the technology.
+- Project team — in this section, list the project team and their contact details. It is useful for the MDN team to know who is responsible for a project at a glance, as well as external people who might want to provide feedback or help with the documentation work.
+- See also — in here, include any other links you think might be useful.
+
+#### Reference pages
+
+Each reference page type should have a template defined. These will likely be different in structure to the reference page types you see on the core MDN site, but that's OK. Feel free to use our pages for guidance/inspiration, and talk to your MDN rep for help.
+
+#### Guides/tutorials
+
+The structure of guides/tutorials can be anything you like, as long as it proves effective in teaching readers what they need to know. Again, feel free to look to some of our guides for inspiration.
+
+### Project metadata
+
+By project metadata, we mean things like:
+
+- Team contact details, if you'd rather put them on a separate page.
+- Project-specific language or code guidelines.
+- Code templates to write new examples into.
+- Reusable asset lists.
+
+## Maintenance
+
+The documentation will need to be maintained to remain on MDN:
+
+- MDN is a Wiki; when others make changes to the docs, a core community member for that technology needs to review those changes to make sure the content is still good. This can be done via MDN's ["Watch" functionality](/en-US/docs/MDN/Contribute/Tools/Page_watching).
+- When changes occur to the technology that require documentation updates, the community needs to make updates as appropriate, keeping the same standards and process in mind as the original documentation.
+
+## Archiving documentation
+
+If the documentation appears to be:
+
+- Stale/unmaintained
+- Stalled without being finished
+- Low quality
+- Becoming obsolete
+
+If positive changes are not observed over a period of 6 months, it will be considered dead documentation, and will be archived. If you are having trouble with meeting the requirements for a successful documentation project, please reach out to your MDN rep and discuss it. We can try to work through the issues together if we know what they are; silence is never a solution.
+
+We need to be strict on such matters — we can't let the site fill up with bad quality, incomplete, or obsolete documentation — it harms our reputation.

--- a/contrib-docs/how-to-write/what-we-write.md
+++ b/contrib-docs/how-to-write/what-we-write.md
@@ -10,9 +10,9 @@ tags:
 ---
 <{{MDNSidebar}}>
 
-Be aware that all contributions to MDN fall under specific open source licenses; these are [described in detail](/en-US/docs/MDN/About#copyrights_and_licenses) on our [About MDN](/en-US/docs/MDN/About) page.
+In this article, you'll find information about whether or not a given topic and/or type of content should be included on MDN.
 
-> **Note:** Keep in mind that Mozilla's [Websites & Communications Terms of Use](https://www.mozilla.org/en-US/about/legal/terms/mozilla/) are in effect when you use or contribute to MDN Web Docs. Review this document to ensure that you're aware of what can and cannot be posted on Mozilla sites.
+> **Note:** Be aware that all contributions to MDN fall under specific open source licenses; these are [described in detail](/en-US/docs/MDN/About#copyrights_and_licenses) on our [About MDN](/en-US/docs/MDN/About) page. Keep in mind that Mozilla's [Websites & Communications Terms of Use](https://www.mozilla.org/en-US/about/legal/terms/mozilla/) are in effect when you use or contribute to MDN. <!--- links need to be revisited--->
 
 ## Topics that belong on MDN
 

--- a/contrib-docs/how-to-write/what-we-write.md
+++ b/contrib-docs/how-to-write/what-we-write.md
@@ -10,82 +10,59 @@ tags:
 ---
 <{{MDNSidebar}}>
 
-In this article, you'll find information about whether or not a given topic and/or type of content should be included on MDN.
+MDN Web Docs contains _browser-neutral_ documentation that enables web developers to write _browser-agnostic_ code. In this article, you'll find information about whether or not a given topic and/or type of content should be included on MDN Web Docs.
 
 > **Note:** Be aware that all contributions to MDN fall under specific open source licenses; these are [described in detail](/en-US/docs/MDN/About#copyrights_and_licenses) on our [About MDN](/en-US/docs/MDN/About) page. Keep in mind that Mozilla's [Websites & Communications Terms of Use](https://www.mozilla.org/en-US/about/legal/terms/mozilla/) are in effect when you use or contribute to MDN. <!--- links need to be revisited--->
 
-## Topics that belong on MDN
+## Topics that belong on MDN Web Docs
 
-In general, if it's an open web-facing technology, we document it on MDN. This includes any feature that can be used by web developers creating websites and applications, now and in the near future. If a feature is implemented by multiple browsers and either accepted as standard or is progressing towards standardization, then yes, we definitely document it here. If a feature is still very experimental and not implemented in multiple browsers and/or liable to change, then it is still suitable for inclusion, but may not be seen as a priority for the writer's team to work on.
+In general, if it's an open web technology, we document it on MDN Web Docs. This includes any feature that can be used by web developers creating websites and applications, now and in the near future.
+
+If a feature is implemented by multiple browsers and either accepted as standard or is progressing towards standardization, then yes, we definitely document it here. If a feature is still very experimental and not implemented in multiple browsers and/or liable to change, then it is still suitable for inclusion, but may not be seen as a priority for the writer's team to work on.
+<!-- need to follow up on Ruth's feedback here: https://github.com/mdn/content-team-projects/pull/20#discussion_r865151254 -->
+
+In other words, web technologies to be documented on MDN Web Docs should fulfil the following criteria:
+
+- Be on a standards track.
+- Be specified in a specification published by a reliable standards body.
+- Be implemented by at least one rendering engine.
+
+Variations in browser support are documented in the [browser compatibility](/en-US/docs/MDN/Structures/Compatibility_tables) section of an article. <!--- check for update in link to Structures/Compatibility_tables --->
 
 Our primary focus is to write about the following front-end web technologies:
 
 - [HTML](/en-US/docs/Web/HTML)
 - [CSS](/en-US/docs/Web/CSS)
 - [JavaScript](/en-US/docs/Web/JavaScript)
-- [SVG](/en-US/docs/Web/SVG)
 - [Web APIs](/en-US/docs/Web/API)
-- [WebGL](/en-US/docs/Web/API/WebGL_API)
-- etc.
 
-And so, you too can contribute towards these topic areas.
+We also document some broader topics, such as [SVG](/en-US/docs/Web/SVG), [XML](/en-US/docs/Web/XML), [WebAssembly](/en-US/docs/WebAssembly), and [Accessibility](/en-US/docs/Learn/Accessibility). In addition, we provide extensive [learning guides](/en-US/docs/Learn) for these technologies and also a [glossary](/en-US/docs/Glossary).
 
-> **Note:** Back-end technologies usually have their own documentation elsewhere that MDN does not attempt to supersede, although we [do have some exceptions](/en-US/docs/Learn/Server-side).
+> **Note:** Backend technologies usually have their own documentation elsewhere that MDN Web Docs does not attempt to supersede, although we [do have some exceptions](/en-US/docs/Learn/Server-side).
 
-We also welcome topics that cut across technologies but are relevant to web development, such as:
+All content on MDN Web Docs must be relevant to the technology section in which it appears. Contributors are expected to follow the [MDN guidelines](/en-US/docs/MDN/Guidelines) for writing style, code samples, and other topics. <!--- link needs to be revisited--->
 
-- [Accessibility](/en-US/docs/Web/Accessibility)
-- [AJAX](/en-US/docs/Web/Guide/AJAX)
-- [Web graphics](/en-US/docs/Web/Guide/Graphics)
-- [Progressive web apps](/en-US/docs/Web/Progressive_web_apps)
-- [Web-based games](/en-US/docs/Games)
+For more details on acceptance criteria for whether or not a technology can be documented on MDN Web Docs, see the [Criteria for inclusion]<!--- add link--->
 
-> **Note:** MDN covers some non-standard features if they're exposed to the web, especially if they find common usage; for example, we have documentation for WebKit-specific CSS properties. MDN also covers some non-web standards technologies if they are considered useful enough to web developers (see our [Web-related technologies](/en-US/docs/Related) section).
+## Topics that don't belong on MDN Web Docs
 
-## Topics that don't belong on MDN
+In general, anything that isn't an open web standard does not belong on MDN Web Docs. Spam (commercial advertisement) and other irrelevant content will never be accepted into the site. Contributors who keep trying to submit spam may be banned from MDN at the discretion of Mozilla MDN staff.
 
-In general, anything that isn't an open web standard does not belong on MDN.
+Examples of inappropriate topics for MDN Web Docs include:
 
-Examples of inappropriate topics for MDN include:
-
-- Technology that is not exposed to the web and is specific to a non-Mozilla browser.
-- Technology that is not related to the web or Mozilla products.
+- Technology that is not exposed to the web and is specific to a browser.
+- Technology that is not related to the web.
 - Documentation for end-users. For Mozilla products, for example, such documentation belongs on the [Mozilla support site](https://support.mozilla.org).
+- Self-linking or self-promoting external links. Check out these guidelines before adding an external link. <!--- add link to guidelines for external links --->
 
-## Types of documents that belong on MDN
+## Types of documents that belong on MDN Web Docs
 
-In general, MDN is for _product_ documentation, not for _project_ or _process_ documentation (except [about MDN itself](/en-US/docs/MDN)). So, if the document is about "how to use a thing" or "how a thing works" (where, the "thing" is in one of the topic categories mentioned above), then it can go on MDN. But if it is about "who's working on developing a thing" or "plans for developing a thing", then it shouldn't go on MDN. In that case, if the thing is being developed under the umbrella of Mozilla, then the [Mozilla project wiki](https://wiki.mozilla.org/Main_Page) may be a good place for it.
+In general, MDN Web Docs is for _product_ documentation, not for _project_ or _process_ documentation (except [about MDN itself](/en-US/docs/MDN)). So, if the document is about "how to use a thing" or "how a thing works" (where, the "thing" is in one of the topic categories mentioned above), then it can go on MDN Web Docs. But if it is about "who's working on developing a thing" or "plans for developing a thing", then it shouldn't go on MDN Web Docs. In that case, if the thing is being developed under the umbrella of Mozilla, then the [Mozilla project wiki](https://wiki.mozilla.org/Main_Page) may be a good place for it.
 
-Here are some examples of types of documents that should _not_ be placed on MDN:
+Here are some examples of types of documents that should _not_ be placed on MDN Web Docs:
 
 - Planning documents
 - Design documents
 - Project proposals
 - Specifications or standards
-- Promotional material, advertising, or [personal information](#about_your_profile)
-
-## Editorial policies that govern the content on MDN
-
-This section describes the policies set by the Mozilla MDN staff to govern the content on MDN. All contributors are expected to abide by these policies.
-
-### Relevance
-
-All content on MDN must be relevant to the technology section in which it appears. Spam (commercial advertisement) and other irrelevant content will never be accepted onto the site. Contributors who keep trying to submit spam may be banned from MDN at the discretion of Mozilla MDN staff.
-
-<!--- Outbound links to commercial sites that are relevant to the topic from which they are linked will be judged on a case-by-case basis. Their value in aiding web developers must outweigh the commercial benefit to the linked site. [need to add link to External Links guidelines]--->
-
-### Neutrality
-
-Article content on MDN must maintain a [neutral point-of-view](https://en.wikipedia.org/wiki/Wikipedia:Neutral_point_of_view), reporting on browser variations without editorial bias. Derogatory comments about any browser or user agent are not acceptable.
-
-MDN contains _browser-neutral_ documentation that enables web developers to write _browser-agnostic_ code.
-
-Web technologies to be documented on MDN should be on a standard track and be implemented by at least one rendering engine. Variations in browser support are documented in the [browser compatibility](/en-US/docs/MDN/Structures/Compatibility_tables) section of an article.
-
-### Structure
-
-Reference pages should follow the same structure as other pages of the same type. See [Page Types](/en-US/docs/MDN/Structures/Page_types) for a list and examples of common page structures. <!--- needs to be revisited--->
-
-### Guidelines
-
-Contributors are expected to follow the [MDN guidelines](/en-US/docs/MDN/Guidelines) for writing style, code samples, and other topics. <!--- needs to be revisited--->
+- Promotional material, advertising, or personal information

--- a/contrib-docs/how-to-write/what-we-write.md
+++ b/contrib-docs/how-to-write/what-we-write.md
@@ -1,0 +1,91 @@
+---
+title: What we write
+slug: <MDN/Contribute/how-to-write/what-we-write>
+tags:
+  - <Guide>
+  - <Guidelines>
+  - Writing
+  - Documentation
+  - MDN Meta
+---
+<{{MDNSidebar}}>
+
+Be aware that all contributions to MDN fall under specific open source licenses; these are [described in detail](/en-US/docs/MDN/About#copyrights_and_licenses) on our [About MDN](/en-US/docs/MDN/About) page.
+
+> **Note:** Keep in mind that Mozilla's [Websites & Communications Terms of Use](https://www.mozilla.org/en-US/about/legal/terms/mozilla/) are in effect when you use or contribute to MDN Web Docs. Review this document to ensure that you're aware of what can and cannot be posted on Mozilla sites.
+
+## Topics that belong on MDN
+
+In general, if it's an open web-facing technology, we document it on MDN. This includes any feature that can be used by web developers creating websites and applications, now and in the near future. If a feature is implemented by multiple browsers and either accepted as standard or is progressing towards standardization, then yes, we definitely document it here. If a feature is still very experimental and not implemented in multiple browsers and/or liable to change, then it is still suitable for inclusion, but may not be seen as a priority for the writer's team to work on.
+
+Our primary focus is to write about the following front-end web technologies:
+
+- [HTML](/en-US/docs/Web/HTML)
+- [CSS](/en-US/docs/Web/CSS)
+- [JavaScript](/en-US/docs/Web/JavaScript)
+- [SVG](/en-US/docs/Web/SVG)
+- [Web APIs](/en-US/docs/Web/API)
+- [WebGL](/en-US/docs/Web/API/WebGL_API)
+- etc.
+
+And so, you too can contribute towards these topic areas.
+
+> **Note:** Back-end technologies usually have their own documentation elsewhere that MDN does not attempt to supersede, although we [do have some exceptions](/en-US/docs/Learn/Server-side).
+
+We also welcome topics that cut across technologies but are relevant to web development, such as:
+
+- [Accessibility](/en-US/docs/Web/Accessibility)
+- [AJAX](/en-US/docs/Web/Guide/AJAX)
+- [Web graphics](/en-US/docs/Web/Guide/Graphics)
+- [Progressive web apps](/en-US/docs/Web/Progressive_web_apps)
+- [Web-based games](/en-US/docs/Games)
+
+> **Note:** MDN covers some non-standard features if they're exposed to the web, especially if they find common usage; for example, we have documentation for WebKit-specific CSS properties. MDN also covers some non-web standards technologies if they are considered useful enough to web developers (see our [Web-related technologies](/en-US/docs/Related) section).
+
+## Topics that don't belong on MDN
+
+In general, anything that isn't an open web standard does not belong on MDN.
+
+Examples of inappropriate topics for MDN include:
+
+- Technology that is not exposed to the web and is specific to a non-Mozilla browser.
+- Technology that is not related to the web or Mozilla products.
+- Documentation for end-users. For Mozilla products, for example, such documentation belongs on the [Mozilla support site](https://support.mozilla.org).
+
+## Types of documents that belong on MDN
+
+In general, MDN is for _product_ documentation, not for _project_ or _process_ documentation (except [about MDN itself](/en-US/docs/MDN)). So, if the document is about "how to use a thing" or "how a thing works" (where, the "thing" is in one of the topic categories mentioned above), then it can go on MDN. But if it is about "who's working on developing a thing" or "plans for developing a thing", then it shouldn't go on MDN. In that case, if the thing is being developed under the umbrella of Mozilla, then the [Mozilla project wiki](https://wiki.mozilla.org/Main_Page) may be a good place for it.
+
+Here are some examples of types of documents that should _not_ be placed on MDN:
+
+- Planning documents
+- Design documents
+- Project proposals
+- Specifications or standards
+- Promotional material, advertising, or [personal information](#about_your_profile)
+
+## Editorial policies that govern the content on MDN
+
+This section describes the policies set by the Mozilla MDN staff to govern the content on MDN. All contributors are expected to abide by these policies.
+
+### Relevance
+
+All content on MDN must be relevant to the technology section in which it appears. Spam (commercial advertisement) and other irrelevant content will never be accepted onto the site. Contributors who keep trying to submit spam may be banned from MDN at the discretion of Mozilla MDN staff.
+
+<!--- Outbound links to commercial sites that are relevant to the topic from which they are linked will be judged on a case-by-case basis. Their value in aiding web developers must outweigh the commercial benefit to the linked site. [need to add link to External Links guidelines]--->
+
+### Neutrality
+
+Article content on MDN must maintain a [neutral point-of-view](https://en.wikipedia.org/wiki/Wikipedia:Neutral_point_of_view), reporting on browser variations without editorial bias. Derogatory comments about any browser or user agent are not acceptable.
+
+MDN contains _browser-neutral_ documentation that enables web developers to write _browser-agnostic_ code.
+
+Web technologies to be documented on MDN should be on a standard track and be implemented by at least one rendering engine. Variations in browser support are documented in the [browser compatibility](/en-US/docs/MDN/Structures/Compatibility_tables) section of an article.
+
+### Structure
+
+Reference pages should follow the same structure as other pages of the same type. See [Page Types](/en-US/docs/MDN/Structures/Page_types) for a list and examples of common page structures. <!--- needs to be revisited--->
+
+### Guidelines
+
+Contributors are expected to follow the [MDN guidelines](/en-US/docs/MDN/Guidelines) for writing style, code samples, and other topics. <!--- needs to be revisited--->


### PR DESCRIPTION
**Notes:**
- Currently calling this file `what-we-write.md`.
- Plan to rename this file to `index.md` and move it into `/content-team-projects/contrib-docs/how-to-write/what-we-write`, assuming the parent folder will be called `what-we-write`.
- `slug`, `tags`, and `sidebar` need to be revisited
- The landing page for 'how to write' will be done after I have all the subpages in place.

## Summary
This file covers "What we document" for the [issue#17](https://github.com/mdn/content-team-projects/issues/17). This file merges content from [Does this belong on MDN](https://developer.mozilla.org/en-US/docs/MDN/Guidelines/Does_this_belong_on_MDN) and [Editorial policies](https://developer.mozilla.org/en-US/docs/MDN/Guidelines/Editorial).

> 37 guidelines/does_this_belong_on_MDN: Use for What We Document. Remove, redirect
> 38 guidelines/editorial: Editorial policies - same as above

Scope Update: https://github.com/mdn/content-team-projects/pull/20#issuecomment-1118614526

## Detailed changes
1. Updated the TOC, including the page title, from:

Page title: "Does this belong on MDN Web Docs"
  - The question
  - What topics belong on MDN Web Docs?
  - What topics don't belong on MDN Web Docs?
  - What types of documents belong on MDN?

to: 
Page title: "What we write"
  - Topics that belong on MDN
  - Topics that don’t belong on MDN
  - Types of documents that don’t belong on MDN
  - Editorial policies that govern the content on MDN


2. Deleted these: [Mozilla products](https://developer.mozilla.org/en-US/docs/MDN/Guidelines/Does_this_belong_on_MDN#mozilla_products) and [Mozilla-specific sections](https://developer.mozilla.org/en-US/docs/MDN/Guidelines/Editorial#mozilla-specific_sections)

3. Added some comments in the markdown file as a reminder to revisit links and text.